### PR TITLE
Cache invalidation

### DIFF
--- a/Queil.FscHost.sln
+++ b/Queil.FscHost.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{66F5D23D-95D6-4460-A5A7-9F159AECC712}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Queil.FSharp.FscHost", "src\Queil.FSharp.FscHost\Queil.FSharp.FscHost.fsproj", "{083C0401-78B6-478F-8171-DF2093FF035F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E407C524-3F23-4EA2-8403-2B350C40B621}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Queil.FSharp.FscHost.Tests", "tests\unit\Queil.FSharp.FscHost.Tests.fsproj", "{A3BC9F79-88A2-4ED4-8849-A4388DC75C1D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{083C0401-78B6-478F-8171-DF2093FF035F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{083C0401-78B6-478F-8171-DF2093FF035F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{083C0401-78B6-478F-8171-DF2093FF035F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{083C0401-78B6-478F-8171-DF2093FF035F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3BC9F79-88A2-4ED4-8849-A4388DC75C1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3BC9F79-88A2-4ED4-8849-A4388DC75C1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3BC9F79-88A2-4ED4-8849-A4388DC75C1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3BC9F79-88A2-4ED4-8849-A4388DC75C1D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{083C0401-78B6-478F-8171-DF2093FF035F} = {66F5D23D-95D6-4460-A5A7-9F159AECC712}
+		{A3BC9F79-88A2-4ED4-8849-A4388DC75C1D} = {E407C524-3F23-4EA2-8403-2B350C40B621}
+	EndGlobalSection
+EndGlobal

--- a/src/Queil.FSharp.FscHost/Errors.fs
+++ b/src/Queil.FSharp.FscHost/Errors.fs
@@ -1,10 +1,19 @@
 namespace Queil.FSharp.FscHost
 
+open System
+
 [<AutoOpen>]
 module Errors =
   exception NuGetRestoreFailed of message: string
-  exception ScriptParseError of errors: string seq
-  exception ScriptCompileError of errors: string seq
+  
+  type ScriptParseError(messages : string seq) =
+    inherit Exception(String.Join(Environment.NewLine, messages))
+    member _.Diagnostics = messages
+
+   type ScriptCompileError(messages : string seq) =
+    inherit Exception(String.Join(Environment.NewLine, messages))
+    member _.Diagnostics = messages
+  
   exception ScriptModuleNotFound of path: string * moduleName: string
   exception ScriptMemberHasInvalidType of memberName: string * actualTypeSignature: string
   exception ScriptMemberNotFound of memberName: string * foundMembers: string list

--- a/src/Queil.FSharp.FscHost/FscHost.fs
+++ b/src/Queil.FSharp.FscHost/FscHost.fs
@@ -174,7 +174,7 @@ module CompilerHost =
                   | path when path.EndsWith(".dll") -> Some path
                   | _ -> None)
                 |> Seq.groupBy id
-                |> Seq.map (fun (path, _) -> path)
+                |> Seq.map fst
             | _ -> raise (ScriptParseError (projResults.Diagnostics |> Seq.map string))
         | _ -> return raise (ScriptParseError (errors |> Seq.map string) )
       }

--- a/src/Queil.FSharp.FscHost/FscHost.fs
+++ b/src/Queil.FSharp.FscHost/FscHost.fs
@@ -47,7 +47,7 @@ type Options =
   {
     Compiler: CompilerOptions
     UseCache: bool
-    CachePath: string
+    CacheDir: string
     Logger: string -> unit
   }
 with 
@@ -55,7 +55,7 @@ with
     {
       Compiler = CompilerOptions.Default
       UseCache = false
-      CachePath = Path.Combine(".fsc-host", "cache")
+      CacheDir = Path.Combine(".fsc-host", "cache")
       Logger = ignore
     }
 
@@ -95,7 +95,7 @@ module CompilerHost =
       async {
 
         if options.UseCache then
-          Directory.CreateDirectory options.CachePath |> ignore
+          Directory.CreateDirectory options.CacheDir |> ignore
 
         let maybeCachedFileName =
           if options.UseCache then
@@ -103,7 +103,7 @@ module CompilerHost =
             let computeHash (s:string) = s |> Encoding.UTF8.GetBytes |> sha256.ComputeHash |> BitConverter.ToString |> fun s -> s.Replace("-", "")
             let fileHash filePath = File.ReadAllText filePath |> computeHash
             let combinedHash = projOptions.SourceFiles |> Seq.map fileHash |> Seq.reduce (fun a b -> a + b) |> computeHash
-            Some (Path.Combine(options.CachePath.TrimEnd('\\','/'), $"{combinedHash}.dll"))
+            Some (Path.Combine(options.CacheDir.TrimEnd('\\','/'), $"{combinedHash}.dll"))
           else None
         
         match maybeCachedFileName with

--- a/src/Queil.FSharp.FscHost/FscHost.fs
+++ b/src/Queil.FSharp.FscHost/FscHost.fs
@@ -26,14 +26,14 @@ with
       Args = fun scriptPath refs opts ->
         [
         "-a"; scriptPath
-        sprintf "--targetprofile:%s" opts.TargetProfile
-        sprintf "--target:%s" opts.Target
-        sprintf "--warn:%i" opts.WarningLevel
+        $"--targetprofile:%s{opts.TargetProfile}"
+        $"--target:%s{opts.Target}"
+        $"--warn:%i{opts.WarningLevel}"
         yield! refs
-        match opts.IncludeHostEntryAssembly with | true -> sprintf "-r:%s" (Assembly.GetEntryAssembly().GetName().Name) |_ -> ()
-        match opts.LangVersion with | Some ver -> sprintf "--langversion:%s" ver | _ -> ()
+        match opts.IncludeHostEntryAssembly with | true -> $"-r:%s{Assembly.GetEntryAssembly().GetName().Name}" |_ -> ()
+        match opts.LangVersion with | Some ver -> $"--langversion:%s{ver}" | _ -> ()
         for s in opts.Symbols do
-          sprintf "--define:%s" s
+          $"--define:%s{s}"
         ]
       IncludeHostEntryAssembly = true
       LangVersion = None
@@ -72,7 +72,7 @@ module CompilerHost =
         | File path -> path
         | Inline _ -> 
           let path = Path.GetTempFileName()
-          sprintf "%s%s.fsx" (Path.GetTempPath()) (Path.GetFileNameWithoutExtension path)
+          $"%s{Path.GetTempPath()}%s{Path.GetFileNameWithoutExtension path}.fsx"
 
       let createInlineScriptFile (filePath:string) =
         function
@@ -88,7 +88,7 @@ module CompilerHost =
       let log = options.Logger
       let loadNuGetAssemblies nugetPaths =
         nugetPaths |> Seq.iter (fun path -> 
-          sprintf "Loading assembly: %s" path |> log
+          $"Loading assembly: %s{path}" |> log
           path |> Assembly.LoadFrom |> ignore
         )
 
@@ -106,9 +106,9 @@ module CompilerHost =
         
         match maybeCachedFileName with
         | Some path when File.Exists path ->
-          sprintf "Found and loading cached assembly: %s" path |> log
+          $"Found and loading cached assembly: %s{path}" |> log
           let nuGetFile = Path.ChangeExtension (path, "nuget")
-          sprintf "Loading cached NuGet resolutions file: %s" nuGetFile |> log
+          $"Loading cached NuGet resolutions file: %s{nuGetFile}" |> log
           nuGetFile |> File.ReadAllLines |> loadNuGetAssemblies
           return path |> Path.GetFullPath |> Assembly.LoadFile
           
@@ -118,7 +118,7 @@ module CompilerHost =
           nuGetsPaths |> loadNuGetAssemblies
           maybePath |> Option.iter (fun path -> 
             let nuGetFile = Path.ChangeExtension (path, "nuget")
-            sprintf "Caching resolved NuGets to: %s" nuGetFile |> log
+            $"Caching resolved NuGets to: %s{nuGetFile}" |> log
             (nuGetFile, nuGetsPaths) |> File.WriteAllLines
           )
 

--- a/src/Queil.FSharp.FscHost/Plugin.fs
+++ b/src/Queil.FSharp.FscHost/Plugin.fs
@@ -61,7 +61,7 @@ module Plugin =
       let options = {state.State.options with Logger =  logFun} 
       CommonBuilder { state.State with options = options }
      
-     /// Defines the name of a binding to extract. Default: plugin
+    /// Defines the name of a binding to extract. Default: plugin
     [<CustomOperation("binding")>]
     member x.Binding(state: CommonBuilder, name: string) =
       CommonBuilder { state.State with bindingName = name }

--- a/src/Queil.FSharp.FscHost/Plugin.fs
+++ b/src/Queil.FSharp.FscHost/Plugin.fs
@@ -55,6 +55,12 @@ module Plugin =
       let options = {state.State.options with UseCache = useCache} 
       CommonBuilder { state.State with options = options }
     
+    /// Overrides the default cache dir path. It is only relevant if cache is enabled. Default: .fsc-host/cache
+    [<CustomOperation("cache_dir")>]
+    member x.CacheDir(state: CommonBuilder, cacheDir: string) =
+      let options = {state.State.options with CacheDir = cacheDir} 
+      CommonBuilder { state.State with options = options }
+    
     /// Enables a custom logging function
     [<CustomOperation("log")>]
     member x.Log(state: CommonBuilder, logFun: string -> unit) =

--- a/src/Queil.FSharp.FscHost/Reflection.fs
+++ b/src/Queil.FSharp.FscHost/Reflection.fs
@@ -43,8 +43,7 @@ module internal Reflection =
         match (f, p) with
         | f, p when p.IsGenericMethodParameter ->
           if s.GenericParams.ContainsKey(p) && s.GenericParams.[p] <> f then
-            failwithf "Failed to add type '%s' as a substitute for generic parameter type '%s'. It already has a substitute (%s)" 
-              (f.ToString()) (p.ToString()) (s.GenericParams.[p].ToString())
+            failwithf $"Failed to add type '%s{f.ToString()}' as a substitute for generic parameter type '%s{p.ToString()}'. It already has a substitute (%s{s.GenericParams.[p].ToString()})"
           else s.GenericParams.TryAdd(p, f) |> ignore
         | (FsFunc (fi, fo)), (FsFunc (pi, po)) ->
           handle fi pi s

--- a/src/Queil.FSharp.FscHost/Reflection.fs
+++ b/src/Queil.FSharp.FscHost/Reflection.fs
@@ -45,7 +45,7 @@ module internal Reflection =
           if s.GenericParams.ContainsKey(p) && s.GenericParams.[p] <> f then
             failwithf $"Failed to add type '%s{f.ToString()}' as a substitute for generic parameter type '%s{p.ToString()}'. It already has a substitute (%s{s.GenericParams.[p].ToString()})"
           else s.GenericParams.TryAdd(p, f) |> ignore
-        | (FsFunc (fi, fo)), (FsFunc (pi, po)) ->
+        | FsFunc (fi, fo), FsFunc (pi, po) ->
           handle fi pi s
           handle fo po s
         | _ -> ()
@@ -58,7 +58,7 @@ module internal Reflection =
         let v = Var(p.Name, f)
         Expr.Lambda(v, build fs' ps' { s with Vars = v::s.Vars })
 
-      | (FsTuple us as f)::_, p::ps' when s.Index < us.Length ->
+      | FsTuple us as f::_, p::ps' when s.Index < us.Length ->
         handleGenerics us.[s.Index] p s
         let v = Var($"{p.Name}_{s.Index}", us.[s.Index])
         let expr tv = Expr.Let(v, Expr.TupleGet(Expr.Var tv, s.Index),
@@ -69,11 +69,11 @@ module internal Reflection =
           let tupleVar = Var("tupledArg", f)
           Expr.Lambda(tupleVar, expr tupleVar)
 
-      | (FsTuple _ as f)::fs', p::_ ->
+      | FsTuple _ as f::fs', p::_ ->
         handleGenerics f p s
         build fs' ps { s with Index = 0; TupleVar = None }
 
-      | (FsFunc _ as f)::fs', p::ps' ->
+      | FsFunc _ as f::fs', p::ps' ->
         handleGenerics f p s
         let v = Var(p.Name, f)
         Expr.Lambda(v, build fs' ps' { s with Vars = v::s.Vars })

--- a/tests/unit/Cache.Tests.fs
+++ b/tests/unit/Cache.Tests.fs
@@ -1,0 +1,66 @@
+module Queil.FSharp.FscHost.Cache.Tests
+
+open Expecto
+open Queil.FSharp.FscHost.Plugin
+open System.IO
+
+[<Tests>]
+let cacheTests =
+  testList "Cache invalidation" [
+    let asScript filePath lines = File.WriteAllLines(filePath, lines |> Seq.toArray)
+    
+    testAsync "File script" {
+      let tmpPath = Path.Combine(Path.GetTempPath(), "fsc-host", Path.GetRandomFileName())
+      Directory.CreateDirectory tmpPath |> ignore
+      let scriptDir = tmpPath
+      let rootScriptName = "script.fsx"
+      let rootScriptPath = Path.Combine(scriptDir, rootScriptName)
+      let fileA = Path.Combine(scriptDir, "depa.fsx")
+      let fileB = Path.Combine(scriptDir, "depb.fsx")
+
+      [
+        $"""#load "%s{fileB.Replace(@"\", @"\\")}" """
+        """let valueA = 11"""
+      ] |> asScript fileA
+      
+      [
+        """let valueB = 13"""
+      ] |> asScript fileB
+      
+      [
+        $"""#load "%s{fileA.Replace(@"\", @"\\")}" """
+        """let plugin = Some (Depa.valueA * Depb.valueB) """
+      ] |> asScript rootScriptPath
+
+      let plugin () = 
+        plugin<int option> {
+          load
+          dir scriptDir
+          file rootScriptName
+          cache true
+          compiler (fun x -> { x with LangVersion = Some "preview" } )
+        }
+      
+      let! firstResult = plugin ()  
+      
+      let result = "Some int expected" |> Expect.wantSome firstResult
+      "Result should be '143'" |> Expect.equal result 143
+      
+      // editing non-root files should also dump the cache
+      // and re-compiling should return the updated result
+      [
+        $"""#load "%s{fileB}" """
+        """let valueA = 17"""
+      ] |> asScript fileA
+      
+      [
+        """let valueB = 19"""
+      ] |> asScript fileB
+      
+      let! secondResult = plugin ()  
+      
+      let result = "Some int expected" |> Expect.wantSome secondResult
+      "Result should be '323'" |> Expect.equal result 323
+      
+    }
+  ]

--- a/tests/unit/Core.Tests.fs
+++ b/tests/unit/Core.Tests.fs
@@ -204,10 +204,10 @@ module Func =
     ()
 
 """
-      let (resultFunc, sideEffect) = invoke <| fun () ->
+      let resultFunc, sideEffect = invoke <| fun () ->
         Inline script |>
           CompilerHost.getMember2 options
-            (Member<(float * int) -> string -> int -> unit option -> string>.Path "Test.Script.Func.myFunc")
+            (Member<float * int -> string -> int -> unit option -> string>.Path "Test.Script.Func.myFunc")
             (Member<unit -> unit>.Path "Test.Script.Func.sideEffect")
              |> Async.RunSynchronously
 
@@ -230,10 +230,10 @@ module Func =
     sprintf "tuple1: (%f, %i) - tuple2: (%s, %A)" t1f t1i (t2s ()) (t2s' "")
 
 """
-      let (resultFunc) = invoke <| fun () ->
+      let resultFunc = invoke <| fun () ->
         Inline script |>
           CompilerHost.getMember options
-            (Member<(float * int) -> ((_ -> string) * (string -> _))-> string>.Path "Test.Script.Func.myFunc")
+            (Member<float * int -> (_ -> string) * (string -> _) -> string>.Path "Test.Script.Func.myFunc")
              |> Async.RunSynchronously
       //this tests fails when the unit in fun () -> "test" is replaced by fun x -> "test"
       let result = resultFunc (2.0, 8) ((fun () -> "test"), (fun _ -> ()))
@@ -249,7 +249,7 @@ module Func =
   let myFunc something = sprintf "Generic: %A" something
 
 """
-      let (resultFunc) = invoke <| fun () ->
+      let resultFunc = invoke <| fun () ->
         Inline script |>
           CompilerHost.getMember options
             (Member<_ -> string>.Path "Test.Script.Func.myFunc")
@@ -268,7 +268,7 @@ module Func =
   let myFunc something toB : 'b = something |> toB
 
 """
-      let (resultFunc) = invoke <| fun () ->
+      let resultFunc = invoke <| fun () ->
         Inline script |>
           CompilerHost.getMember options
             (Member<_ -> (_ -> _) -> _>.Path "Test.Script.Func.myFunc")

--- a/tests/unit/Core.Tests.fs
+++ b/tests/unit/Core.Tests.fs
@@ -16,7 +16,7 @@ let invoke<'a> (func:unit -> 'a) =
   | ScriptCompileError errors -> 
     failwithf "%s" (errors |> String.concat "\n")
   | ScriptMemberHasInvalidType (propertyName, actualTypeSignature) ->
-    printfn "Diagnostics: Property '%s' should be of type '%s' but is '%s'" propertyName (typeof<'a>.ToString()) actualTypeSignature
+    printfn $"Diagnostics: Property '%s{propertyName}' should be of type '%s{typeof<'a>.ToString()}' but is '%s{actualTypeSignature}'"
     reraise ()
 
 [<Tests>]
@@ -274,7 +274,7 @@ module Func =
             (Member<_ -> (_ -> _) -> _>.Path "Test.Script.Func.myFunc")
              |> Async.RunSynchronously
 
-      let result = resultFunc (2.0, 8) <| fun (a, b) -> sprintf "Generic: (%f, %i)" a b
+      let result = resultFunc (2.0, 8) <| fun (a, b) -> $"Generic: (%f{a}, %i{b})"
       
       "Values should be equal" |> Expect.equal result "Generic: (2.000000, 8)"
     }

--- a/tests/unit/Core.Tests.fs
+++ b/tests/unit/Core.Tests.fs
@@ -12,9 +12,7 @@ let options =
 let invoke<'a> (func:unit -> 'a) =
   try
     func ()
-  with 
-  | ScriptCompileError errors -> 
-    failwithf "%s" (errors |> String.concat "\n")
+  with
   | ScriptMemberHasInvalidType (propertyName, actualTypeSignature) ->
     printfn $"Diagnostics: Property '%s{propertyName}' should be of type '%s{typeof<'a>.ToString()}' but is '%s{actualTypeSignature}'"
     reraise ()

--- a/tests/unit/Plugin.Tests.fs
+++ b/tests/unit/Plugin.Tests.fs
@@ -1,11 +1,18 @@
 module Queil.FSharp.FscHost.Plugin.Tests
 
+open System.IO
 open Expecto
 open Queil.FSharp.FscHost.Plugin
 open System
 
 [<Tests>]
 let ceTests =
+  
+  let ensureTempPath () =
+    let tmpPath = Path.Combine(Path.GetTempPath(), "fsc-host", Path.GetRandomFileName())
+    Directory.CreateDirectory tmpPath |> ignore
+    tmpPath
+  
   testList "Plugin builder" [
     
     testAsync "Inline script" {
@@ -46,14 +53,15 @@ module OtherPlugin =
     }
      
     testAsync "File script" {
-      let fileName = "/tmp/plugin.builder.file.fsx"
+      let tmpDir = ensureTempPath ()
+      let fileName = Path.Combine(tmpDir, "plugin.builder.file.fsx")
       let lines = ["""let plugin = Some "test971" """]
-      IO.File.WriteAllLines(fileName, lines)
+      File.WriteAllLines(fileName, lines)
       
       let! plugin =
         plugin<string option> {
           load
-          dir "/tmp"
+          dir tmpDir
           file "plugin.builder.file.fsx"
           cache true
           compiler (fun x -> { x with LangVersion = Some "preview" } )
@@ -63,14 +71,15 @@ module OtherPlugin =
     }
     
     testAsync "File script - w/binding" {
-      let fileName = "/tmp/plugin.builder.binding.file.fsx"
+      let tmpDir = ensureTempPath ()
+      let fileName = Path.Combine(tmpDir, "plugin.builder.binding.file.fsx")
       let lines = ["""let export = Some "test971" """]
-      IO.File.WriteAllLines(fileName, lines)
+      File.WriteAllLines(fileName, lines)
       
       let! plugin =
         plugin<string option> {
           load
-          dir "/tmp"
+          dir tmpDir
           file "plugin.builder.binding.file.fsx"
           binding "export"
           cache true

--- a/tests/unit/Queil.FSharp.FscHost.Tests.fsproj
+++ b/tests/unit/Queil.FSharp.FscHost.Tests.fsproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="Core.Tests.fs" />
     <Compile Include="Plugin.Tests.fs" />
+    <Compile Include="Cache.Tests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR introduces a full cached assembly invalidation (i.e. based on all the script files included in a compilation, and not only the root script file)