### PR TITLE
Delete generated paket deps if invalid

### DIFF
--- a/src/Queil.FSharp.DependencyManager.Paket/Queil.FSharp.DependencyManager.Paket.fsproj
+++ b/src/Queil.FSharp.DependencyManager.Paket/Queil.FSharp.DependencyManager.Paket.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Update="FSharp.Core" Version="[8.0.101]" />
+    <PackageReference Update="FSharp.Core" Version="[8.0.300]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Queil.FSharp.FscHost/FscHost.fs
+++ b/src/Queil.FSharp.FscHost/FscHost.fs
@@ -89,7 +89,7 @@ type ScriptCache =
                     { x with
                         SourceFiles = v :: x.SourceFiles }
                 | _ -> failwith $"Could not parse line: %s{s} in file: %s{path}")
-            (ScriptCache.Default)
+            ScriptCache.Default
         |> fun x -> { x with FilePath = path }
 
     member cache.Save() =
@@ -250,7 +250,6 @@ module CompilerHost =
     open Internals
 
     let getAssembly (options: Options) (script: Script) : Async<CompileOutput> =
-
 
         async {
             let (rootFilePath, scriptDir, cacheDir) =

--- a/src/Queil.FSharp.FscHost/Queil.FSharp.FscHost.fsproj
+++ b/src/Queil.FSharp.FscHost/Queil.FSharp.FscHost.fsproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="FSharp.Compiler.Service" Version="[43.8.101]" />
-    <PackageReference Update="FSharp.Core" Version="[8.0.101]" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="[43.8.300]" />
+    <PackageReference Update="FSharp.Core" Version="[8.0.300]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Queil.FSharp.FscHost/packages.lock.json
+++ b/src/Queil.FSharp.FscHost/packages.lock.json
@@ -2440,11 +2440,11 @@
     "net8.0": {
       "FSharp.Compiler.Service": {
         "type": "Direct",
-        "requested": "[43.8.101, 43.8.101]",
-        "resolved": "43.8.101",
-        "contentHash": "z+gIwhbAoLIQw0fNkCAbur/vevDzFOQ11FHVS1Q8YaIEamw2XprRbv2zjLIc82sHqEk69hN/cyzDhC9YxAYkxw==",
+        "requested": "[43.8.300, 43.8.300]",
+        "resolved": "43.8.300",
+        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
         "dependencies": {
-          "FSharp.Core": "[8.0.101]",
+          "FSharp.Core": "[8.0.300]",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "7.0.0",
           "System.Diagnostics.DiagnosticSource": "7.0.2",
@@ -2456,9 +2456,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[8.0.101, 8.0.101]",
-        "resolved": "8.0.101",
-        "contentHash": "sOLz3O4BOxnTKfd5OChdRmDUy4Id0GfoEClRG4nzIod8LY1LJZcNyygKAV0A78XOLh8yvhA5hsDYKZXGCR9blw=="
+        "requested": "[8.0.300, 8.0.300]",
+        "resolved": "8.0.300",
+        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
       },
       "Chessie": {
         "type": "Transitive",
@@ -3454,7 +3454,7 @@
       "queil.fsharp.dependencymanager.paket": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[8.0.101, 8.0.101]",
+          "FSharp.Core": "[8.0.300, 8.0.300]",
           "Paket.Core": "[8.0.3, )"
         }
       }

--- a/tests/unit/Queil.FSharp.FscHost.Tests.fsproj
+++ b/tests/unit/Queil.FSharp.FscHost.Tests.fsproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Expecto" Version="10.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Update="FSharp.Core" Version="8.0.101" />
+    <PackageReference Update="FSharp.Core" Version="8.0.300" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Delete the generated `dependencies.paket` file if invalid, so that it can be regenerated. This is important in an interactive scenarios when editing paket dependencies in a script.