### PR TITLE
fix: load assemblies into a new context

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas": {
+      "version": "6.3.12",
+      "commands": [
+        "fantomas"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -27,7 +27,7 @@ steps:
     projects: tests/unit
     arguments: '-c Release /p:AltCover=true /p:AltCoverCobertura=coverage.xml /p:AltCoverAssemblyFilter="(.*)(?<!Queil.FSharp.FscHost)$"'
 
-- task: PublishCodeCoverageResults@1
+- task: PublishCodeCoverageResults@2
   inputs:
     summaryFileLocation: tests/unit/coverage.xml
     codeCoverageTool: cobertura

--- a/src/Queil.FSharp.FscHost/Errors.fs
+++ b/src/Queil.FSharp.FscHost/Errors.fs
@@ -4,8 +4,6 @@ open System
 
 [<AutoOpen>]
 module Errors =
-    exception NuGetRestoreFailed of message: string
-
     type ScriptParseError(messages: string seq) =
         inherit Exception(String.Join(Environment.NewLine, messages))
         member _.Diagnostics = messages

--- a/src/Queil.FSharp.FscHost/FscHost.fs
+++ b/src/Queil.FSharp.FscHost/FscHost.fs
@@ -204,7 +204,8 @@ module CompilerHost =
 
                     return
                         { AssemblyFilePath = path
-                          Assembly = Lazy<Assembly>(fun () -> path |> Path.GetFullPath |> asmLoadContext.LoadFromAssemblyPath ) }
+                          Assembly =
+                            Lazy<Assembly>(fun () -> path |> Path.GetFullPath |> asmLoadContext.LoadFromAssemblyPath) }
 
                 | path ->
 
@@ -236,7 +237,10 @@ module CompilerHost =
                     let getAssembly () =
                         async {
                             let! errors, _ = checker.Compile(compilerArgs |> List.toArray, "None")
-                            return getAssemblyOrThrow errors (fun () -> path |> Path.GetFullPath |> asmLoadContext.LoadFromAssemblyPath)
+
+                            return
+                                getAssemblyOrThrow errors (fun () ->
+                                    path |> Path.GetFullPath |> asmLoadContext.LoadFromAssemblyPath)
                         }
 
                     let! assembly = getAssembly ()
@@ -246,7 +250,8 @@ module CompilerHost =
 
                     return
                         { AssemblyFilePath = outputDllName
-                          Assembly = Lazy<Assembly>(fun () -> path |> Path.GetFullPath |> asmLoadContext.LoadFromAssemblyPath) }
+                          Assembly =
+                            Lazy<Assembly>(fun () -> path |> Path.GetFullPath |> asmLoadContext.LoadFromAssemblyPath) }
             }
 
     open Internals

--- a/tests/unit/Common.fs
+++ b/tests/unit/Common.fs
@@ -1,5 +1,7 @@
 namespace Queil.FSharp.FscHost
 
+open System.IO
+
 module Common =
 
     let options =
@@ -15,3 +17,8 @@ module Common =
                 $"Diagnostics: Property '%s{propertyName}' should be of type '%s{typeof<'a>.ToString()}' but is '%s{actualTypeSignature}'"
 
             reraise ()
+
+    let ensureTempPath () =
+        let tmpPath = Path.Combine(Path.GetTempPath(), "fsc-host", Path.GetRandomFileName())
+        Directory.CreateDirectory tmpPath |> ignore
+        tmpPath

--- a/tests/unit/Paket.Tests.fs
+++ b/tests/unit/Paket.Tests.fs
@@ -2,6 +2,8 @@ module Queil.FSharp.FscHost.Paket.Tests
 
 open Expecto
 open Queil.FSharp.FscHost
+open Queil.FSharp.FscHost.Common
+open System.IO
 
 [<Tests>]
 let paketTests =
@@ -64,5 +66,45 @@ let paketTests =
               resultFunc ()
           }
 
+          test "Should crash" {
+              let script =
+                  """
+                      #r "paket: 
+                            nuget Fake.Core.Trace = 6.1.0"
+                      
+                      namespace Script
+      
+                      module X =
+      
+                          let x () = 10 |> printfn "%i"
+                    """
 
-          ]
+              let tmpDir = ensureTempPath ()
+
+              let script2 =
+                  """
+                     #r "nuget: Fake.Core.Environment, 6.0.0"
+                          """
+
+              let scriptPath1 = $"{tmpDir}/script.fsx"
+              let scriptPath2 = $"{tmpDir}/script2.fsx"
+              File.WriteAllText(scriptPath1, script)
+              File.WriteAllText(scriptPath2, script2)
+
+              let main = $"""
+                #load "{scriptPath1}"
+                #load "{scriptPath2}"
+              """
+
+
+              let resultFunc =
+                  Common.invoke
+                  <| fun () ->
+                      Inline main
+                      |> CompilerHost.getMember
+                          { options with UseCache = false }
+                          (Member<unit -> unit>.Path("Script.X.x"))
+                      |> Async.RunSynchronously
+
+              resultFunc ()
+          } ]

--- a/tests/unit/Paket.Tests.fs
+++ b/tests/unit/Paket.Tests.fs
@@ -64,47 +64,4 @@ let paketTests =
                       |> Async.RunSynchronously
 
               resultFunc ()
-          }
-
-          test "Should crash" {
-              let script =
-                  """
-                      #r "paket: 
-                            nuget Fake.Core.Trace = 6.1.0"
-                      
-                      namespace Script
-      
-                      module X =
-      
-                          let x () = 10 |> printfn "%i"
-                    """
-
-              let tmpDir = ensureTempPath ()
-
-              let script2 =
-                  """
-                     #r "nuget: Fake.Core.Environment, 6.0.0"
-                          """
-
-              let scriptPath1 = $"{tmpDir}/script.fsx"
-              let scriptPath2 = $"{tmpDir}/script2.fsx"
-              File.WriteAllText(scriptPath1, script)
-              File.WriteAllText(scriptPath2, script2)
-
-              let main = $"""
-                #load "{scriptPath1}"
-                #load "{scriptPath2}"
-              """
-
-
-              let resultFunc =
-                  Common.invoke
-                  <| fun () ->
-                      Inline main
-                      |> CompilerHost.getMember
-                          { options with UseCache = false }
-                          (Member<unit -> unit>.Path("Script.X.x"))
-                      |> Async.RunSynchronously
-
-              resultFunc ()
           } ]

--- a/tests/unit/Plugin.Tests.fs
+++ b/tests/unit/Plugin.Tests.fs
@@ -3,15 +3,11 @@ module Queil.FSharp.FscHost.Plugin.Tests
 open System.IO
 open Expecto
 open Queil.FSharp.FscHost.Plugin
+open Queil.FSharp.FscHost.Common
 open System
 
 [<Tests>]
 let ceTests =
-
-    let ensureTempPath () =
-        let tmpPath = Path.Combine(Path.GetTempPath(), "fsc-host", Path.GetRandomFileName())
-        Directory.CreateDirectory tmpPath |> ignore
-        tmpPath
 
     testList
         "Plugin builder"

--- a/tests/unit/Queil.FSharp.FscHost.Tests.fsproj
+++ b/tests/unit/Queil.FSharp.FscHost.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Paket.Tests.fs" />
     <Compile Include="Plugin.Tests.fs" />
     <Compile Include="Cache.Tests.fs" />
+    <Compile Include="Runtime.Tests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/tests/unit/Runtime.Tests.fs
+++ b/tests/unit/Runtime.Tests.fs
@@ -1,0 +1,24 @@
+module Queil.FSharp.FscHost.Runtime.Tests
+
+open Expecto
+open Queil.FSharp.FscHost
+
+[<Tests>]
+let tests =
+    testList
+        "Runtime"
+        [ test "Should be able to load System.Security.Cryptography.ProtectedData" {
+              let script =
+                  """
+                    #r "paket: nuget System.Security.Cryptography.ProtectedData >= 8.0.0"
+                    """
+
+              Common.invoke
+              <| fun () ->
+                  Inline script
+                  |> CompilerHost.getAssembly Common.options
+                  |> Async.RunSynchronously
+                  |> _.Assembly.Value
+                  |> ignore
+
+          } ]


### PR DESCRIPTION
This PR fixes `System.IO.FileLoadException` when loading certain assemblies. For example:

```
#r "nuget: System.Security.Cryptography.ProtectedData, 8.0.0"
```

Results with:

```
Unhandled exception. System.IO.FileLoadException: Could not load file or assembly 'System.Security.Cryptography.ProtectedData, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
   at System.Runtime.Loader.AssemblyLoadContext.LoadFromPath(IntPtr ptrNativeAssemblyBinder, String ilPath, String niPath, ObjectHandleOnStack retAssembly)
   at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyPath(String assemblyPath)
   at System.Reflection.Assembly.LoadFrom(String assemblyFile)
   at Queil.FSharp.FscHost.CompilerHost.Internals.loadNuGetAssemblies@181-1.Invoke(String path)
   at Microsoft.FSharp.Collections.SeqModule.Iterate[T](FSharpFunc`2 action, IEnumerable`1 source) in D:\a\_work\1\s\src\FSharp.Core\seq.fs:line 632
   at Queil.FSharp.FscHost.CompilerHost.Internals.compileScript@186.Invoke(Unit unitVar)
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 510
   at Queil.FSharp.FscHost.CompilerHost.buildMetadata@285-7.Invoke(AsyncActivation`1 ctxt)
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 112
--- End of stack trace from previous location ---
   at Microsoft.FSharp.Control.AsyncResult`1.Commit() in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 454
   at Microsoft.FSharp.Control.AsyncPrimitives.QueueAsyncAndWaitForResultSynchronously[a](CancellationToken token, FSharpAsync`1 computation, FSharpOption`1 timeout) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 1140
   at Microsoft.FSharp.Control.AsyncPrimitives.RunSynchronously[T](CancellationToken cancellationToken, FSharpAsync`1 computation, FSharpOption`1 timeout) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 1167
   at Microsoft.FSharp.Control.FSharpAsync.RunSynchronously[T](FSharpAsync`1 computation, FSharpOption`1 timeout, FSharpOption`1 cancellationToken) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 1511
   at Program.compileScript@38.Invoke(ParseResults`1 args, Script script) in /home/vsts/work/1/s/src/fsy/Program.fs:line 90
   at <StartupCode$fsy>.$Program.main@() in /home/vsts/work/1/s/src/fsy/Program.fs:line 104
Aborted (core dumped)
```