### PR TITLE
fix: the cache hash should not depend on filename ordering

### DIFF
--- a/src/Queil.FSharp.FscHost/FscHost.fs
+++ b/src/Queil.FSharp.FscHost/FscHost.fs
@@ -137,8 +137,8 @@ module CompilerHost =
 
             let combinedHash =
                 sourceFiles
-                |> Seq.sort
                 |> Seq.map fileHash
+                |> Seq.sort
                 |> Seq.reduce (fun a b -> a + b)
                 |> sha256
 
@@ -271,7 +271,10 @@ module CompilerHost =
                                 let metadata =
                                     { ScriptCache.Default with
                                         FilePath = cacheDepsFilePath
-                                        SourceFiles = projOptions.SourceFiles |> Seq.toList }
+                                        SourceFiles = projOptions.SourceFiles |> Seq.except [rootFilePath] |> Seq.toList }
+                                log "Source files:"
+                                for sf in metadata.SourceFiles do
+                                    log $"  %s{sf}"
 
                                 if options.Compiler.Standalone then
                                     return Ok metadata

--- a/src/Queil.FSharp.FscHost/FscHost.fs
+++ b/src/Queil.FSharp.FscHost/FscHost.fs
@@ -271,7 +271,7 @@ module CompilerHost =
                                 let metadata =
                                     { ScriptCache.Default with
                                         FilePath = cacheDepsFilePath
-                                        SourceFiles = projOptions.SourceFiles |> Seq.except [rootFilePath] |> Seq.toList }
+                                        SourceFiles = projOptions.SourceFiles |> Seq.toList }
                                 log "Source files:"
                                 for sf in metadata.SourceFiles do
                                     log $"  %s{sf}"
@@ -298,17 +298,7 @@ module CompilerHost =
                         }
 
                     if File.Exists cacheDepsFilePath then
-                        log $"Loading cached metadata from: %s{cacheDepsFilePath}"
-                        let c = ScriptCache.Load cacheDepsFilePath
-                        let missingSourceFiles = c.SourceFiles |> Seq.filter (not << File.Exists) |> Seq.toList
-
-                        match missingSourceFiles with
-                        | [] -> return Ok c
-                        | files ->
-                            log $"Cached metadata is stale: %s{cacheDepsFilePath}"
-                            for f in files do log $"Source file: %s{f} is missing"
-                            log "Rebuilding metadata"
-                            return! buildMetadata ()
+                        return Ok (ScriptCache.Load cacheDepsFilePath)
                     else
                         return! buildMetadata ()
                 }


### PR DESCRIPTION
This PR makes the cache hash independent of file names basing solely on the content. Also it removes redundant metadata cache invalidation when the source files no longer exist. It is not needed because the output dll and all the NuGet information is already cached and lack of source files doesn't affect the cached assembly.